### PR TITLE
Manually import Proxy from Data.Proxy

### DIFF
--- a/src/Data/Fold/Internal.hs
+++ b/src/Data/Fold/Internal.hs
@@ -16,9 +16,10 @@ module Data.Fold.Internal
   ) where
 
 import Control.Applicative
-import Data.Data
+import Data.Data (Data, Typeable)
 import Data.Foldable
 import Data.Monoid hiding (First, Last)
+import Data.Proxy (Proxy(Proxy))
 import Data.Reflection
 import Data.Traversable
 


### PR DESCRIPTION
While GHC 7.8 provides Proxy in Data.Data, previous versions do not.
