### PR TITLE
Fix bug in first/second implementation of Arrow instances

### DIFF
--- a/src/Data/Fold/L1'.hs
+++ b/src/Data/Fold/L1'.hs
@@ -85,10 +85,10 @@ instance Arrow L1' where
   arr h = L1' h (\_ a -> a) id
   {-# INLINE arr #-}
   first (L1' k h z) = L1' (first k) h' (first z) where
-    h' (a,b) (c,_) = (h a c, b)
+    h' (a,_) (c,b) = (h a c, b)
   {-# INLINE first #-}
   second (L1' k h z) = L1' (second k) h' (second z) where
-    h' (a,b) (_,c) = (a, h b c)
+    h' (_,b) (a,c) = (a, h b c)
   {-# INLINE second #-}
   L1' k h z *** L1' k' h' z' = L1' (k *** k') h'' (z *** z') where
     h'' (a,b) (c,d) = (h a c, h' b d)

--- a/src/Data/Fold/L1.hs
+++ b/src/Data/Fold/L1.hs
@@ -90,10 +90,10 @@ instance Arrow L1 where
   arr h = L1 h (\_ a -> a) id
   {-# INLINE arr #-}
   first (L1 k h z) = L1 (first k) h' (first z) where
-    h' (a,b) (c,_) = (h a c, b)
+    h' (a,_) (c,b) = (h a c, b)
   {-# INLINE first #-}
   second (L1 k h z) = L1 (second k) h' (second z) where
-    h' (a,b) (_,c) = (a, h b c)
+    h' (_,b) (a,c) = (a, h b c)
   {-# INLINE second #-}
   L1 k h z *** L1 k' h' z' = L1 (k *** k') h'' (z *** z') where
     h'' (a,b) (c,d) = (h a c, h' b d)

--- a/src/Data/Fold/M1.hs
+++ b/src/Data/Fold/M1.hs
@@ -93,10 +93,10 @@ instance Arrow M1 where
   arr h = M1 h id const
   {-# INLINE arr #-}
   first (M1 k h m) = M1 (first k) (first h) m' where
-    m' (a,b) (c,_) = (m a c, b)
+    m' (a,_) (c,b) = (m a c, b)
   {-# INLINE first #-}
   second (M1 k h m) = M1 (second k) (second h) m' where
-    m' (a,b) (_,c) = (a, m b c)
+    m' (_,b) (a,c) = (a, m b c)
   {-# INLINE second #-}
   M1 k h m *** M1 k' h' m' = M1 (k *** k') (h *** h') m'' where
     m'' (a,b) (c,d) = (m a c, m' b d)

--- a/src/Data/Fold/R1.hs
+++ b/src/Data/Fold/R1.hs
@@ -90,10 +90,10 @@ instance Arrow R1 where
   arr h = R1 h const id
   {-# INLINE arr #-}
   first (R1 k h z) = R1 (first k) h' (first z) where
-    h' (a,b) (c,_) = (h a c, b)
+    h' (a,_) (c,b) = (h a c, b)
   {-# INLINE first #-}
   second (R1 k h z) = R1 (second k) h' (second z) where
-    h' (a,b) (_,c) = (a, h b c)
+    h' (_,b) (a,c) = (a, h b c)
   {-# INLINE second #-}
   R1 k h z *** R1 k' h' z' = R1 (k *** k') h'' (z *** z') where
     h'' (a,b) (c,d) = (h a c, h' b d)


### PR DESCRIPTION
When we receive a new value, the new unlifted component should replace the
old, as opposed to the old value persisting, as was the case.
