### PR TITLE
Removed duplicate strict pair from L'.hs

### DIFF
--- a/src/Data/Fold/L'.hs
+++ b/src/Data/Fold/L'.hs
@@ -102,16 +102,14 @@ instance Comonad (L' a) where
   extend f (L' k h z)  = L' (f . L' k h) h z
   {-# INLINE extend #-}
 
-data Pair a b = Pair !a !b
-
 instance Applicative (L' a) where
   pure b = L' (\() -> b) (\() _ -> ()) ()
   {-# INLINE pure #-}
 
   L' xf bxx xz <*> L' ya byy yz = L'
-    (\(Pair x y) -> xf x $ ya y)
-    (\(Pair x y) b -> Pair (bxx x b) (byy y b))
-    (Pair xz yz)
+    (\(Pair' x y) -> xf x $ ya y)
+    (\(Pair' x y) b -> Pair' (bxx x b) (byy y b))
+    (Pair' xz yz)
   {-# INLINE (<*>) #-}
 
   (<*) m = \_ -> m


### PR DESCRIPTION
There seems to be an old implementation of strict pairs lying around in `L1.hs` that is identical to the one found in `Data.Fold.Internal.hs`.